### PR TITLE
Added an instancied rendering method

### DIFF
--- a/src/app.h
+++ b/src/app.h
@@ -22,7 +22,7 @@ private:
 
 public:
   // Creates rendering application.  Initialises the renderer
-  app(const std::string& title = "Render Framework", renderer::ScreenMode sm = renderer::windowed, unsigned int width = 1280, unsigned int height = 720);
+  app(const std::string& title = "Render Framework", renderer::ScreenMode sm = renderer::windowed, unsigned int width = 1980, unsigned int height = 1024);
   // Deleted copy, move constructor and assignment operator
   app(const app &other) = delete;
   app(app &&other) = delete;

--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -662,10 +662,86 @@ void renderer::render(const geometry &geom) throw(...) {
   }
 }
 
+
+// Renders a piece of geometry
+void renderer::render_instancieted(const geometry &geom, GLuint instancesNumber) throw(...) {
+	assert(geom.get_array_object() != 0);
+	// Check renderer is running
+	assert(_instance->_running);
+	// Bind the vertex array object for the
+	glBindVertexArray(geom.get_array_object());
+
+	// Check for any OpenGL errors
+	if (CHECK_GL_ERROR) {
+		// Display error
+		std::cerr << "ERROR - rendering geometry" << std::endl;
+		std::cerr << "Could not bind vertex array object" << std::endl;
+		// Throw exception
+		throw std::runtime_error("Error rendering geometry");
+	}
+	// If there is an index buffer then use to render
+	if (geom.get_idx_buffer() != 0) {
+		// Bind index buffer
+		glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, geom.get_idx_buffer());
+		// Check for error
+		if (CHECK_GL_ERROR) {
+			std::cerr << "ERROR - rendering geometry" << std::endl;
+			std::cerr << "Could not bind index buffer" << std::endl;
+			// Throw exception
+			throw std::runtime_error("Error rendering geometry");
+		}
+		// Draw elements
+		glDrawElementsInstanced(geom.get_type(), geom.get_index_count(), GL_UNSIGNED_INT, 0, instancesNumber);
+		// Check for error
+		if (CHECK_GL_ERROR) {
+			// Display error
+			std::cerr << "ERROR - rendering geometry" << std::endl;
+			std::cerr << "Could not draw elements from indices" << std::endl;
+			// Throw exception
+			throw std::runtime_error("Error rendering geometry");
+		}
+	}
+	else {
+		// Draw arrays
+		glDrawArraysInstanced(geom.get_type(), 0, geom.get_vertex_count(), instancesNumber);
+		// Check for error
+		if (CHECK_GL_ERROR) {
+			std::cerr << "ERROR - rendering geometry" << std::endl;
+			std::cerr << "Could not draw arrays" << std::endl;
+			// Throw exception
+			throw std::runtime_error("Error rendering geometry");
+		}
+	}
+}
+
 // Renders a piece of geometry
 void renderer::render(const mesh &m) throw(...) {
   // Render geometry
   render(m.get_geometry());
+}
+
+// Renders a piece of geometry
+void renderer::render_instancieted(const mesh &m, GLuint instancesNumber) throw(...) {
+
+	// Enable the glVertexAttributeArray 5 to be overloaded as a matrix
+	glEnableVertexAttribArray(5);
+	glVertexAttribPointer(5, 4, GL_FLOAT, GL_FALSE, sizeof(glm::mat4), (GLvoid*)0);
+	glEnableVertexAttribArray(6);
+	glVertexAttribPointer(6, 4, GL_FLOAT, GL_FALSE, sizeof(glm::mat4), (GLvoid*)(sizeof(glm::vec4)));
+	glEnableVertexAttribArray(7);
+	glVertexAttribPointer(7, 4, GL_FLOAT, GL_FALSE, sizeof(glm::mat4), (GLvoid*)(2 * sizeof(glm::vec4)));
+	glEnableVertexAttribArray(8);
+	glVertexAttribPointer(8, 4, GL_FLOAT, GL_FALSE, sizeof(glm::mat4), (GLvoid*)(3 * sizeof(glm::vec4)));
+
+	glVertexAttribDivisor(5, 1);
+	glVertexAttribDivisor(6, 1);
+	glVertexAttribDivisor(7, 1);
+	glVertexAttribDivisor(8, 1);
+
+	glBindVertexArray(0);
+
+	// Render geometry
+	render_instancieted(m.get_geometry(), instancesNumber);
 }
 
 // Sets the render target of the renderer to the screen

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -101,8 +101,12 @@ public:
   static void bind(const std::vector<spot_light> &spots, const std::string &name) throw(...);
   // Renders a piece of geometry
   static void render(const geometry &geom) throw(...);
+  // Renders a piece of geometry as instancied array
+  static void render_instancieted(const geometry &geom, GLuint instancesNumber) throw(...);
   // Renders a mesh object
   static void render(const mesh &m) throw(...);
+  // Renders mesh object as instancied array
+  static void render_instancieted(const mesh & m, GLuint instancesNumber) throw(...);
   // Sets the render target of the renderer to the screen
   static void set_render_target() throw(...);
   // Sets the render target of the renderer to a shadow map


### PR DESCRIPTION
As per suggestion by mail, I have added a rendering_instancied method. This one following the tutorial uses a transform matrix to calculate the offsets.

The only extra code required in the main, outside the rapper would be something along the lines of:

// sets up the buffer
	GLuint buffer;
	glGenBuffers(1, &buffer);
	glBindBuffer(GL_ARRAY_BUFFER, buffer);
	glBufferData(GL_ARRAY_BUFFER, spheresNumber * sizeof(glm::mat4), &NAME-OF-THE-MATRIX[0], GL_STATIC_DRAW);

	// binds the buffer
	GLuint VAO = sphere.get_geometry().get_array_object();
	glBindVertexArray(VAO);


Not sure how bad the code is, considering that I don't know openGL much if at all. If its not useful to you, I will simply edit my cmake to take in my fork instead.

Hope its mildly useful!
Davide